### PR TITLE
Include LICENSE into the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
I came across this while making a conda-forge package for cfgv: conda-forge
usually recommends to include the LICENSE file in the conda package