### PR TITLE
Add WarnAdditionalKeys() as a new check

### DIFF
--- a/cfgv.py
+++ b/cfgv.py
@@ -162,6 +162,12 @@ def _no_additional_keys_check(self, dct):
         )
 
 
+def _warn_additional_keys_check(self, dct):
+    extra = sorted(set(dct) - set(self.keys))
+    if extra:
+        self.callback(extra, self.keys)
+
+
 Required = collections.namedtuple('Required', ('key', 'check_fn'))
 Required.check = _check_required
 Required.apply_default = _dct_noop
@@ -220,6 +226,13 @@ NoAdditionalKeys = collections.namedtuple('NoAdditionalKeys', ('keys',))
 NoAdditionalKeys.check = _no_additional_keys_check
 NoAdditionalKeys.apply_default = _dct_noop
 NoAdditionalKeys.remove_default = _dct_noop
+WarnAdditionalKeys = collections.namedtuple(
+    'WarnAdditionalKeys',
+    ('keys', 'callback'),
+)
+WarnAdditionalKeys.check = _warn_additional_keys_check
+WarnAdditionalKeys.apply_default = _dct_noop
+WarnAdditionalKeys.remove_default = _dct_noop
 
 
 class Map(collections.namedtuple('Map', ('object_name', 'id_key', 'items'))):

--- a/tests/cfgv_test.py
+++ b/tests/cfgv_test.py
@@ -33,6 +33,7 @@ from cfgv import Required
 from cfgv import RequiredRecurse
 from cfgv import validate
 from cfgv import ValidationError
+from cfgv import WarnAdditionalKeys
 
 
 def _assert_exception_trace(e, trace):
@@ -655,3 +656,22 @@ def test_no_additional_keys():
     _assert_exception_trace(excinfo.value, expected)
 
     validate({True: True}, no_additional_keys)
+
+
+warn_additional_keys = Map(
+    'Map', None,
+    Required(True, check_bool),
+    WarnAdditionalKeys((True,), mock.Mock()),
+)
+
+
+def test_warn_additional_keys_when_has_extra_keys():
+    with mock.patch('cfgv.WarnAdditionalKeys.callback') as mocked_callback:
+        validate({True: True, False: False}, warn_additional_keys)
+    assert mocked_callback.called
+
+
+def test_warn_additional_keys_when_no_extra_keys():
+    with mock.patch('cfgv.WarnAdditionalKeys.callback') as mocked_callback:
+        validate({True: True}, warn_additional_keys)
+    assert not mocked_callback.called


### PR DESCRIPTION
 - works similarly as NoAdditionalKeys but do not exit
just prints a warning about extra keys

Signed-off-by: Andras Mitzki <andras.mitzki@gmail.com>

Related PR: 
https://github.com/pre-commit/pre-commit/pull/980

Questions:
1, After several days I am a little bit confused, do we thought change like this?
2, I was thinking about to expose the inner warning message, for now this message is the same as in `NoAdditionalKeys`. The possible fix here can be to return with this message from a new function for example: `additional_keys_msg()`, and use in both `NoAdditionalKeys` and `WarnAdditionalKeys` cases.
3, I like the detail print debugs in `NoAdditionalKeys` (because of the `ValidationError` check), is not it needed here? For now our warning message is only a one line message.
4, Is it enought to check with mocking original function?

