### PR TITLE
Add encoding utf-8 to fixed UnicodeDecodeError

### DIFF
--- a/cfgv.py
+++ b/cfgv.py
@@ -411,7 +411,7 @@ def load_from_filename(
         if not os.path.exists(filename):
             raise ValidationError('{} does not exist'.format(filename))
 
-        with io.open(filename) as f:
+        with io.open(filename, encoding='utf-8') as f:
             contents = f.read()
 
         with validate_context('File {}'.format(filename)):


### PR DESCRIPTION
Sometime files maybe have other language of encoded by UTF-8, ex: Chinese etc.
when this happened, it will raise the UnicodeDecodeError,
so i think add encoding utf-8 for open function, it can fix this problem.