### PR TITLE
Require python3.6.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ classifiers =
 
 [options]
 py_modules = cfgv
-python_requires = >=3.6
+python_requires = >=3.6.1
 
 [bdist_wheel]
 universal = True


### PR DESCRIPTION
[python 3 statement - 3.6.0](https://github.com/asottile/scratch/wiki/python-3-statement#360)

(due to broken `NamedTuple` in 3.6.0)

Committed via https://github.com/asottile/all-repos